### PR TITLE
Only run image build on FNNDSC/pfcon

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
   build:
     needs: [test-pfcon, test-cube]
-    if: github.event_name == 'push' || github.event_name == 'release'
+    if: ${{ github.repository == 'FNNDSC/pfcon' && (github.event_name == 'push' || github.event_name == 'release') }}
     runs-on: ubuntu-20.04
     steps:
       - name: Get git tag


### PR DESCRIPTION
Image builds push to Docker Hub, assuming that the Docker Hub
organization/repo match the GitHub repository/repo. The CI GitHub action
can potentially run on any fork if it has enabled GitHub actions.
The build will therefore likely fail unless code has merged into the
FNNDSC/pfcon repository because it will either:

- Attempt to push a container image to a non-existant repo on Docker Hub
- Will attempt to push a container image anonymously

Fixes https://github.com/team19hackathon2021/issues-chris/issues/97